### PR TITLE
Bug Fix: Exputt losing connection permanently

### DIFF
--- a/src/device_launch_monitor_screenshot.py
+++ b/src/device_launch_monitor_screenshot.py
@@ -80,7 +80,8 @@ class DeviceLaunchMonitorScreenshot(DeviceBase):
         self.main_window.connector_status.setStyleSheet(f"QLabel {{ background-color : {color}; color : white; }}")
         self.main_window.restart_button.setEnabled(restart)
         self.main_window.pause_button.setEnabled(False)
-        self.device_worker.ignore_shots_after_restart()
+        if self.device_worker is not None:
+            self.device_worker.ignore_shots_after_restart()
 
     def __display_training_file(self):
         train_file = 'train'

--- a/src/screenshot_exputt.py
+++ b/src/screenshot_exputt.py
@@ -66,11 +66,13 @@ class ScreenshotExPutt(ScreenshotBase):
         # Check if new shot
         self.new_shot = False
         self.screenshot_new = False
-        mse = 400
+        mse_min = 400
+        mse = mse_min
+
         if not self.previous_screenshot_image is None:
             mse = self.mse(self.previous_screenshot_image, self.screenshot_image)
-        # If mse > 20000 it could be caused by exputt loses it's calibration
-        if mse >= 400 and mse < 20000:
+
+        if mse >= mse_min:
             self.screenshot_new = True
             self.previous_screenshot_image = self.screenshot_image
             self.image()


### PR DESCRIPTION
I've encountered this problem a few times when the exputt camera was temporarily obscured.  There some chance that the connector gets confused about subsequent mse readings, and never recovers.
This change automatically recovers from that.